### PR TITLE
Deploy Opscenter without Hub

### DIFF
--- a/aws/cloud-init.tf
+++ b/aws/cloud-init.tf
@@ -71,6 +71,13 @@ data "template_file" "master" {
     saml_name              = var.saml_name
     saml_admin_group       = var.saml_admin_group
     saml_entity_descriptor = var.saml_entity_descriptor
+
+    // Email alerts
+    alert_recipient = var.alert_recipient
+    alert_smtp_host = var.alert_smtp_host
+    alert_smtp_port = var.alert_smtp_port
+    alert_smtp_user = var.alert_smtp_user
+    alert_smtp_pass = var.alert_smtp_pass
   }
 }
 

--- a/aws/ssm.tf
+++ b/aws/ssm.tf
@@ -122,3 +122,56 @@ resource "aws_ssm_parameter" "saml_entity_descriptor" {
   overwrite   = true
   tags        = local.merged_tags
 }
+
+//
+// Store SMTP / Alerting variables in the SSM parameter store encrypted
+//
+resource "aws_ssm_parameter" "alert_recipient" {
+  count       = var.alert_recipient != "" ? 1 : 0
+  name        = "/telekube/${var.name}/alert/recipient"
+  description = ""
+  type        = "SecureString"
+  value       = var.alert_recipient
+  overwrite   = true
+  tags        = local.merged_tags
+}
+
+resource "aws_ssm_parameter" "alert_smtp_host" {
+  count       = var.alert_smtp_host != "" ? 1 : 0
+  name        = "/telekube/${var.name}/alert/smtp-host"
+  description = ""
+  type        = "SecureString"
+  value       = var.alert_smtp_host
+  overwrite   = true
+  tags        = local.merged_tags
+}
+
+resource "aws_ssm_parameter" "alert_smtp_port" {
+  count       = var.alert_smtp_port != "" ? 1 : 0
+  name        = "/telekube/${var.name}/alert/smtp-port"
+  description = ""
+  type        = "SecureString"
+  value       = var.alert_smtp_port
+  overwrite   = true
+  tags        = local.merged_tags
+}
+
+resource "aws_ssm_parameter" "alert_smtp_user" {
+  count       = var.alert_smtp_user != "" ? 1 : 0
+  name        = "/telekube/${var.name}/alert/smtp-user"
+  description = ""
+  type        = "SecureString"
+  value       = var.alert_smtp_user
+  overwrite   = true
+  tags        = local.merged_tags
+}
+
+resource "aws_ssm_parameter" "alert_smtp_pass" {
+  count       = var.alert_smtp_pass != "" ? 1 : 0
+  name        = "/telekube/${var.name}/alert/smtp-pass"
+  description = ""
+  type        = "SecureString"
+  value       = var.alert_smtp_pass
+  overwrite   = true
+  tags        = local.merged_tags
+}

--- a/aws/vars.tf
+++ b/aws/vars.tf
@@ -211,7 +211,7 @@ variable "oidc_issuer_url" {
 }
 
 //
-// SAML variables for configuraing an identity provider on install
+// SAML variables for configuring an identity provider on install
 //
 variable "saml_name" {
   description = "The display name of this SAML identity provider"
@@ -225,6 +225,34 @@ variable "saml_admin_group" {
 
 variable "saml_entity_descriptor" {
   description = "The SAML IdP metadata in XML format"
+  default     = ""
+}
+
+//
+// SMTP variables for configuring email alerts
+//
+variable "alert_recipient" {
+  description = "The recipient of an email alert"
+  default     = ""
+}
+
+variable "alert_smtp_host" {
+  description = "The SMTP host for sending email alerts"
+  default     = ""
+}
+
+variable "alert_smtp_port" {
+  description = "The SMTP port for sending email alerts"
+  default     = "25"
+}
+
+variable "alert_smtp_user" {
+  description = "The SMTP username for sending email alerts"
+  default     = ""
+}
+
+variable "alert_smtp_pass" {
+  description = "The SMTP password for sending email alerts"
   default     = ""
 }
 


### PR DESCRIPTION
The `--ops-advertise-addr` flag also deploys Hub now. This patch stops using the flag and launches the gravity-site service manually instead. This also includes some fixes to the letsencrypt setup, which was previously broken when the cluster name & ops address deviated. 

Also, I moved the SAML configuration step _inside_ the opscenter deployment `if` clause. SAML doesn't make much sense without the opscenter exposed, as we need a callback endpoint.

I'm aware that this repo might not be fully up-to-date, this PR is mainly for code-review at this point

---

As an update, this now also includes automated setup of the `smtp` and `alerttarget` resources